### PR TITLE
new functions that utilise replicates stored in iter dimension

### DIFF
--- a/R/eqsim_plot_iters.R
+++ b/R/eqsim_plot_iters.R
@@ -1,0 +1,146 @@
+#' @title Plots of the results from eqsim
+#'
+#' @description XXX
+#'
+#' @author Einar Hjorleifsson \email{einar.hjorleifsson@@gmail.com}
+#'
+#' @export
+#'
+#' @param sim An object returned from the function eqsim_run
+#' @param ymax.multiplier A value that acts as a multiplier of the maximum observed
+#' variable being plotted. E.g. 1.2 means that for each of the three panels a, b and c
+#' the ymax is set to 1.2 of the maximum observed recruitment, spawning stock biomass
+#' and yield (catch or landings, depending on user input.
+#' @param catch Boolean, if TRUE (default) returns a plot based on catch. If false
+#' returns a plot based on landings.
+
+eqsim_plot <- function(sim, ymax.multiplier=1.2, catch=TRUE)
+{
+
+  # littleHelper function
+  littleHelper <- function(rbp,dat,Flim) {
+    ymax <- max(dat[,2]*ymax.multiplier)
+    with(rbp,plot(Ftarget,p95,type="l",lty=4,ylab="", xlab="", ylim=c(0,ymax)))
+    #title(ylab=Variable, xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+    #mtext(text = paste("c)", Variable), cex = 0.75, side = 3, line = 0.5)
+    with(rbp,lines(Ftarget,p50, lty = 1))
+    with(rbp,lines(Ftarget,p05, lty = 4))
+    points(dat[,1],dat[,2],pch=21,cex=0.75,bg=1)
+    abline(v=Flim,col="red")
+    text(0.98*Flim,0,"F05",srt=90,pos=3,col="red",cex=0.75)
+  }
+
+
+
+
+  rby <- sim$rby
+  #for (i in c(1,2,4,5)) rby[,i] <- rby[,i]/Scale
+
+  rbp <- sim$rbp
+  #for(i in 3:9) rbp[,i] <- rbp[,i]/Scale
+
+  refs <- sim$Refs
+  #refs[3:6,] <- refs[3:6,]/Scale
+
+  pProfile <- sim$pProfile
+
+  Flim <- sim$Refs[1,1]
+  FCrash5 <- sim$Refs[1,6]
+  FCrash50 <- sim$Refs[1,7]
+  op <- par(mfrow = c(2, 2), mar = c(2.5, 4, 1.5, 1), oma = c(0, 0, 0, 0),
+              cex.axis = 0.75, tcl = 0.25, mgp = c(0, 0.25, 0), las = 1)
+
+  # A: Recruitment plot
+  Variable <- "Recruitment"
+  i <- rbp$variable == Variable
+  littleHelper(rbp[i,],dat=rby[,c("fbar","rec")],Flim)
+  title(ylab=Variable, xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+  mtext(text = paste(sim$id.sim," a) Recruits"), cex = 0.75, side = 3, line = 0.5)
+
+  # B: SSB plot
+  Variable <- "Spawning stock biomass"
+  i <- rbp$variable == Variable
+  littleHelper(rbp[i,],dat=rby[,c("fbar","ssb")],Flim)
+  title(ylab=Variable, xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+  mtext(text = paste("b)", Variable), cex = 0.75, side = 3, line = 0.5)
+
+  # C: Yield plot
+  if (catch)  {
+    # catch versus Fbar
+    Variable <- "Catch"
+    i <- rbp$variable == Variable
+    littleHelper(rbp[i,],dat=rby[,c("fbar","catch")],Flim)
+    # Einar added 29.1.2014
+    with(rbp[i,],lines(Ftarget,Mean, lty = 1, lwd=4,col="red"))
+    title(ylab=Variable, xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+    mtext(text = paste("c)", Variable), cex = 0.75, side = 3, line = 0.5)
+    #add landings
+    j <- rbp$variable == "Landings"
+    with(rbp[j,],lines(Ftarget,p50, lty = 2))
+
+    medianFmsy <- sim$Refs[1,4]
+    catch_at_medianFmsy <- sim$Refs[3,4]
+    meanFmsy <- sim$Refs[1,5]
+    catch_at_meanFmsy <- sim$Refs[3,5]
+
+    lines(rep(medianFmsy,2),c(0,catch_at_medianFmsy),col="brown")
+    text(0.98*medianFmsy,0,"median Fmsy",srt=90,pos=4,col="brown",cex=0.75)
+    lines(rep(meanFmsy,2),c(0,catch_at_meanFmsy),col="brown",lty=2)
+    text(0.98*meanFmsy,0,"mean Fmsy",srt=90,pos=4,col="brown",cex=0.75)
+    #lines(Fscan, catm, lty=1, col = 2)
+    #lines(rep(Fscan[maxcatm], 2), c(0, y.max), lty = 1, col = 5)
+  } else {
+    # landings versus Fbar
+    Variable <- "Landings"
+    i <- rbp$variable == Variable
+    littleHelper(rbp[i,],dat=rby[,c("fbar","landings")],Flim)
+    # Einar added 29.1.2014
+    with(rbp[i,],lines(Ftarget,Mean, lty = 1, lwd=4,col="red"))
+    title(ylab=Variable, xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+    mtext(text = paste("c)", Variable), cex = 0.75, side = 3, line = 0.5)
+    #add catch
+    j <- rbp$variable == "Catch"
+    with(rbp[j,],lines(Ftarget,p50, lty = 2))
+
+    medianFmsy <- sim$Refs[2,4]
+    landings_at_medianFmsy <- sim$Refs[4,4]
+    meanFmsy <- sim$Refs[2,5]
+    landings_at_meanFmsy <- sim$Refs[4,5]
+    lines(rep(medianFmsy,2),c(0,landings_at_medianFmsy),col="brown")
+    lines(rep(meanFmsy,2),c(0,landings_at_meanFmsy),col="brown",lty=2)
+    #lines(Fscan, lanm, lty=1, col = 2)
+    #lines(rep(Fscan[maxlanm], 2), c(0, y.max), lty = 1, col = 5)
+  }
+
+  # D: F versus SSB probability
+
+  Variable = "Blim"
+  i <- pProfile$variable == Variable
+  with(pProfile[i,],plot(Ftarget,value,type="l",lty=1,ylab="", xlab="",col="red"))
+
+  title(ylab="Prob MSY, SSB<Bpa or Blim", xlab="F bar", cex.lab=0.75, line=2.5, cex.main=0.75)
+  mtext(text = "d) Prob MSY and Risk to SSB", cex = 0.75, side = 3, line = 0.5)
+
+  Variable = "Bpa"
+  i <- pProfile$variable == Variable
+  with(pProfile[i,],lines(Ftarget,value,type="l",lty=1,ylab="", xlab="",col="darkgreen"))
+
+  Variable = "pFmsyCatch"
+  i <- pProfile$variable == Variable
+  with(pProfile[i,],lines(Ftarget,value,type="l",lty=1,ylab="", xlab="",col="cyan"))
+
+  Variable = "pFmsyLandings"
+  i <- pProfile$variable == Variable
+  with(pProfile[i,],lines(Ftarget,value,type="l",lty=1,ylab="", xlab="",col="brown"))
+
+  text(0.01,0.8, "SSB<Blim", cex = 0.75, col="red",pos=4)
+  text(0.01,0.85, "SSB<Bpa", cex = 0.75, col="darkgreen",pos=4)
+  text(0.01,0.9, "Prob of cFmsy", cex = 0.75, col="cyan",pos=4)
+  text(0.01,0.95, "Prob of lFmsy", cex = 0.75, col="brown",pos=4)
+
+  lines(c(Flim,Flim), c(0.0,0.05), lty = 2, col = "red")
+  lines(c(0,Flim), c(0.05,0.05), lty = 2, col = "red")
+  text(x = 0.1, y = 0.075, "5%", cex = 0.75, col = "red")
+
+
+}  # end of eqsim_plot

--- a/R/eqsim_plot_iters.R
+++ b/R/eqsim_plot_iters.R
@@ -26,8 +26,8 @@ eqsim_plot_iters <- function(sim, ymax.multiplier=1.2, catch=TRUE)
     with(rbp,lines(Ftarget,p50, lty = 1))
     with(rbp,lines(Ftarget,p05, lty = 4))
     points(dat[rby$iter==1,1],dat[rby$iter==1,2],pch=21,cex=0.75,bg=1)
-    points(dat[!rby$iter==1,1],dat[!rby$iter==1,2],pch=21,cex=0.75,col = grDevices::grey(0, 
-                                                                                         alpha = 0.02))
+    # points(dat[!rby$iter==1,1],dat[!rby$iter==1,2],pch=21,cex=0.75,col = grDevices::grey(0, 
+    #                                                                                      alpha = 0.01))
     abline(v=Flim,col="red")
     text(0.98*Flim,0,"F05",srt=90,pos=3,col="red",cex=0.75)
   }

--- a/R/eqsim_plot_iters.R
+++ b/R/eqsim_plot_iters.R
@@ -25,7 +25,9 @@ eqsim_plot <- function(sim, ymax.multiplier=1.2, catch=TRUE)
     #mtext(text = paste("c)", Variable), cex = 0.75, side = 3, line = 0.5)
     with(rbp,lines(Ftarget,p50, lty = 1))
     with(rbp,lines(Ftarget,p05, lty = 4))
-    points(dat[,1],dat[,2],pch=21,cex=0.75,bg=1)
+    points(dat[rby$iter==1,1],dat[rby$iter==1,2],pch=21,cex=0.75,bg=1)
+    points(dat[!rby$iter==1,1],dat[!rby$iter==1,2],pch=21,cex=0.75,col = grDevices::grey(0, 
+                                                                                         alpha = 0.02))
     abline(v=Flim,col="red")
     text(0.98*Flim,0,"F05",srt=90,pos=3,col="red",cex=0.75)
   }

--- a/R/eqsim_plot_iters.R
+++ b/R/eqsim_plot_iters.R
@@ -14,7 +14,7 @@
 #' @param catch Boolean, if TRUE (default) returns a plot based on catch. If false
 #' returns a plot based on landings.
 
-eqsim_plot <- function(sim, ymax.multiplier=1.2, catch=TRUE)
+eqsim_plot_iters <- function(sim, ymax.multiplier=1.2, catch=TRUE)
 {
 
   # littleHelper function

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -218,7 +218,7 @@ eqsim_run <- function(fit,
   catch <- array(FLCore::catch.n(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))  
   sel <- array(FLCore::harvest(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter)) 
   Fbar <- array(FLCore::fbar(stk.win), dim = c(1, btyr2 - btyr1 + 1, dms$iter)) 
-  sel <- sweep(sel, 2, Fbar, "/")
+  sel <- sweep(sel, c(2,3), Fbar, "/")
 
   if (sel.const == TRUE) { # take means of selection
     sel[] <- apply(sel, 1, mean)

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -127,7 +127,7 @@
 #' }
 #'
 #' @export
-eqsim_run <- function(fit,
+eqsim_run_iters <- function(fit,
                       bio.years = c(-5, -1) + FLCore::dims(fit$stk)$maxyear, # years sample weights, M and mat
                       bio.const = FALSE,
                       sel.years= c(-5, -1) + FLCore::dims(fit$stk)$maxyear, # years sample sel and discard proportion by number from

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -380,7 +380,6 @@ eqsim_run <- function(fit,
     # if rec recruiting year class comes from previous years ssb, as in fish recruiting
     # at age 2 or winter ring herring ageing then run some more initial years
     # using the same initial population
-    # - NOTE roll forward one year incase ssb_lag is 0 so that we always have a year j-1.
     Mats <- wests <- matrix(0, nrow = dms$age, ncol = Nmod)
     
     for (iter in 1:dms$iter){
@@ -388,9 +387,10 @@ eqsim_run <- function(fit,
       wests[,iter] <- west[, rsam[j-1,iter],iter]
     } # replicate specific re sampling of maturity and stock weights
     
+    # - NOTE roll forward one year incase ssb_lag is 0 so that we always have a year j-1.
     for (j in 2:pmax(2, ssb_lag + 2)) {
       Ny[,j,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))
-      ssby[j,] <- colSums(Mat[,rsam[j-1,]] * Ny[,1,] * west[,rsam[j-1,]] / exp(Zpre))
+      ssby[j,] <- colSums(Mats * Ny[,1,] * wests / exp(Zpre)) 
     }
 
     # Years (2 + ssb_lag) to Nrun:

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -439,7 +439,7 @@ eqsim_run <- function(fit,
       # roll population one year forward having decided in the F value
       Ny[ -1, j, ] <- Ny[1:(ages-1), j-1, ] * exp(-Fy[1:(ages-1), j-1, ] - Ms[1:(ages-1),]) # TODO:: check if Ms are done correctly
       # calculate plus group
-      Ny[ages, j, ] <- Ny[ages, j, ] + Ny[ages, j-1, ] * exp(-Fy[ages, j-1, ] - M[ages, rsam[j-1,]])
+      Ny[ages, j, ] <- Ny[ages, j, ] + Ny[ages, j-1, ] * exp(-Fy[ages, j-1, ] - Ms[ages, ])
 
       if (ssb_lag == 0) {
         # calculate ssb ignores contribution of recruiting age 0 fish

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -379,8 +379,15 @@ eqsim_run <- function(fit,
 
     # if rec recruiting year class comes from previous years ssb, as in fish recruiting
     # at age 2 or winter ring herring ageing then run some more initial years
-    # using the same intial population
+    # using the same initial population
     # - NOTE roll forward one year incase ssb_lag is 0 so that we always have a year j-1.
+    Mats <- wests <- matrix(0, nrow = dms$age, ncol = Nmod)
+    
+    for (iter in 1:dms$iter){
+      Mats[,iter] <- Mat[, rsam[j-1,iter],iter]
+      wests[,iter] <- west[, rsam[j-1,iter],iter]
+    } # replicate specific re sampling of maturity and stock weights
+    
     for (j in 2:pmax(2, ssb_lag + 2)) {
       Ny[,j,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))
       ssby[j,] <- colSums(Mat[,rsam[j-1,]] * Ny[,1,] * west[,rsam[j-1,]] / exp(Zpre))

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -221,9 +221,11 @@ eqsim_run <- function(fit,
   sel <- sweep(sel, c(2,3), Fbar, "/")
 
   if (sel.const == TRUE) { # take means of selection
-    sel[,,i][] <- apply(sel[,,i], 1, mean)
-    landings[,,i][] <- apply(landings[,,i], 1, mean)
-    catch[,,i][] <- apply(catch[,,i], 1, mean)
+    for(i in 1:dms$iter){
+      sel[,,i][] <- apply(sel[,,i], 1, mean)
+      landings[,,i][] <- apply(landings[,,i], 1, mean)
+      catch[,,i][] <- apply(catch[,,i], 1, mean)
+    }
   }
 
   # 22.2.2014 Added weight of landings per comment from Carmen

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -424,10 +424,17 @@ eqsim_run <- function(fit,
       Fnext <- exp(Ferr[j,]) * Fnext
 
       # get a selection pattern for each simulation and apply this to get N
-      Zpre <- rep(Fnext, each = length(Fprop)) * Fprop * sel[, rsamsel[j-1,]] + M[, rsam[j-1,]] * Mprop
+      Zpre <- sels <- Ms <- matrix(0, nrow = dms$age, ncol = Nmod)
+      
+      for (iter in 1:dms$iter){
+        sels[,iter] <- sel[, rsamsel[j-1,iter],iter]
+        Ms[,iter] <- M[, rsam[j-1,iter],iter]
+      } # replicate specific resampling of selectivity and M
+      
+      Zpre <- rep(Fnext, each = length(Fprop)) * Fprop * sels + Ms * Mprop
 
       # get Fy
-      Fy[ , j-1, ] <- rep(Fnext, each = ages) * sel[, rsamsel[j-1,]]
+      Fy[ , j-1, ] <- rep(Fnext, each = ages) * sels
 
       # roll population one year forward having decided in the F value
       Ny[ -1, j, ] <- Ny[1:(ages-1), j-1, ] * exp(-Fy[1:(ages-1), j-1, ] - M[1:(ages-1), rsam[j-1,]])

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -221,9 +221,9 @@ eqsim_run <- function(fit,
   sel <- sweep(sel, c(2,3), Fbar, "/")
 
   if (sel.const == TRUE) { # take means of selection
-    sel[] <- apply(sel, 1, mean)
-    landings[]  <- apply(landings, 1, mean)
-    catch[]  <- apply(catch, 1, mean)
+    sel[,,i][] <- apply(sel[,,i], 1, mean)
+    landings[,,i][] <- apply(landings[,,i], 1, mean)
+    catch[,,i][] <- apply(catch[,,i], 1, mean)
   }
 
   # 22.2.2014 Added weight of landings per comment from Carmen

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -443,7 +443,14 @@ eqsim_run <- function(fit,
 
       if (ssb_lag == 0) {
         # calculate ssb ignores contribution of recruiting age 0 fish
-        ssby[j, ] <- apply(array(Mat[, rsam[j,]] * Ny[,j,] * west[, rsam[j,]] / exp(Zpre), c(ages, Nmod)), 2, sum)
+        Mats <- wests <- matrix(0, nrow = dms$age, ncol = Nmod)
+        
+        for (iter in 1:dms$iter){
+          Mats[,iter] <- Mat[, rsam[j,iter],iter]
+          wests[,iter] <- west[, rsam[j,iter],iter]
+        } # replicate specific resampling of maturity and stock weights
+        
+        ssby[j, ] <- apply(array(Mats * Ny[,j,] * wests / exp(Zpre), c(ages, Nmod)), 2, sum)
       }
 
       # simulate recruitment in year j

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -437,7 +437,7 @@ eqsim_run <- function(fit,
       Fy[ , j-1, ] <- rep(Fnext, each = ages) * sels
 
       # roll population one year forward having decided in the F value
-      Ny[ -1, j, ] <- Ny[1:(ages-1), j-1, ] * exp(-Fy[1:(ages-1), j-1, ] - M[1:(ages-1), rsam[j-1,]])
+      Ny[ -1, j, ] <- Ny[1:(ages-1), j-1, ] * exp(-Fy[1:(ages-1), j-1, ] - Ms[1:(ages-1),]) # TODO:: check if Ms are done correctly
       # calculate plus group
       Ny[ages, j, ] <- Ny[ages, j, ] + Ny[ages, j-1, ] * exp(-Fy[ages, j-1, ] - M[ages, rsam[j-1,]])
 

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -491,7 +491,11 @@ eqsim_run <- function(fit,
       ssby[j, ] <- apply(array(Mats * Ny[,j,] * wests / exp(Zpre), c(ages, Nmod)), 2, sum)
       
       # calculate catch.n (should this be j-1?  does it matter?)
-      Cy[, j, ] <- Ny[, j-1, ] * Fy[, j-1, ] / (Fy[, j-1, ] + M[, rsam[j-1,]]) * (1 - exp(-Fy[, j-1, ] - M[, rsam[j-1,]]))
+      for (iter in 1:dms$iter){
+        Ms[,iter] <- M[, rsam[j-1,iter],iter]
+      }
+      
+      Cy[, j, ] <- Ny[, j-1, ] * Fy[, j-1, ] / (Fy[, j-1, ] + Ms) * (1 - exp(-Fy[, j-1, ] - Ms))
     }
 
     # convert to catch weight

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -283,7 +283,15 @@ eqsim_run <- function(fit,
   }
 
   # initial recruitment
+  # Each replicate has its own recruitment values: use mean for each
+  R.initial <- array(aggregate(
+    x = fit$rby$rec,
+    by = list(fit$rby$iter),
+    FUN = mean
+  )$x,
+  dim = c(1, dms$iter))
   R <- R.initial
+  # need to update args to account for this: not urgent
 
   # set up arrays to contain simulations
   ssbs <- cats <- lans <- recs <- array(0, c(7, NF))

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -342,19 +342,22 @@ eqsim_run <- function(fit,
     ############################################################################
     # Population in simulation year 1:
 
-    # Zpre: Z that occurs before spawning
-    Zpre <- Fbar * sel[,rsamsel[1,]] * Fprop + M[,rsam[1,]] * Mprop
-
-    # Zpos: Z that occurs after spawning
-    # Zpos not used anywhere
-    Zpos <- Fbar * (1-Fprop) * sel[,rsamsel[1,]] + M[,rsam[1,]] * (1-Mprop)
-
+    # Zpre & Zpos: Z that occurs before & after spawning respectively
+    Zpre <- Zpos <- matrix(0, nrow = ages, ncol = Nmod)
+    
     # run Z out to age 50 for plus group...
     # TODO:
     # Comments from Carmen: Zcum is a cumulative sum:
     #  There is a matrix of F-at-age and a matrix of M-at-age (each has 49 ages, Nmod replicates)
     #  The F and M matrices are summed, giving Z-at-age (49 ages, Nmod replicates)
-    Ztot <- Fbar * sel[c(1:ages, rep(ages, 49 - ages)), rsamsel[1,]] + M[c(1:ages, rep(ages, 49 - ages)), rsam[1,]]
+    Ztot <- matrix(0, nrow = 49, ncol = Nmod)
+    
+    for (iter in 1:dms$iter){ # sample selectivity from associated Nmod replicate (replicate specific resampling)
+      Zpre[,iter] <- Fbar * sel[,rsamsel[1,iter],iter] * Fprop + M[,rsam[1,iter],iter] * Mprop
+      Zpos[,iter] <- Fbar * (1-Fprop) * sel[,rsamsel[1,iter],iter] + M[,rsam[1,iter],iter] * (1-Mprop)
+      Ztot[,iter] <- Fbar * sel[c(1:ages, rep(ages, 49 - ages)), rsamsel[1,iter],iter] + M[c(1:ages, rep(ages, 49 - ages)), rsam[1,iter],iter]
+      
+    }
     Zcum <- apply(Ztot, 2, function(x) c(0, cumsum(x)))
     # create initial population structure
     N1 <- R * exp(- unname(Zcum))

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -276,9 +276,11 @@ eqsim_run <- function(fit,
 
   rsam <- array(sample(1:ncol(weca), Nrun * Nmod, TRUE), c(Nrun, Nmod))
   rsamsel <- array(sample(1:ncol(sel), Nrun * Nmod, TRUE), c(Nrun, Nmod))
-  Wy[] <- c(weca[, c(rsam)])
-  Wl[] <- c(wela[, c(rsam)])
-  Ry[]  <- c(land.cat[, c(rsamsel)])
+  for(i in 1:dms$iter){ # replicate specific resampling
+    Wy[,,i] <- c(weca[, c(rsam[,i]),i])
+    Wl[,,i] <- c(wela[, c(rsam[,i]),i])
+    Ry[,,i] <- c(land.cat[, c(rsamsel[,i]),i])
+  }
 
   # initial recruitment
   R <- R.initial

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -169,10 +169,11 @@ eqsim_run <- function(fit,
   #  forward simulated years)
   keep <- min(Nrun, 50)
 
-  SR.det <- fit$sr.det[which.max(fit$sr.det$prop),] # SR fit to iter 1 (best fit)
-  SR.sto <- fit$sr.sto # SR fits to uncertainty (i.e. assessment replicates 2+)
-  SR.det <- data.frame(a = SR.det$a, b = SR.det$b, cv = SR.det$cv, model = SR.det$model, iter = 1 )
-  SR <- rbind(SR.det, SR.sto)
+  # SR.det <- fit$sr.det[which.max(fit$sr.det$prop),] # SR fit to iter 1 (best fit)
+  # SR.sto <- fit$sr.sto # SR fits to uncertainty (i.e. assessment replicates 2+)
+  # SR.det <- data.frame(a = SR.det$a, b = SR.det$b, cv = SR.det$cv, model = SR.det$model, iter = 1 )
+  # SR <- rbind(SR.det, SR.sto)
+  SR <- fit$sr.sto
   data <- fit$rby[,c("rec","ssb","year", "iter")]
   stk <- fit$stk
   dms <- FLCore::dims(stk) # for array building/looping

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -203,6 +203,17 @@ eqsim_run <- function(fit,
   M <- array(FLCore::m(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
   landings <- array(FLCore::landings.n(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
   # if zero, use 0.10 of minimum value
+  
+  # TODO: check if below is required with Simon Fischer
+  # compute catch for each replicate: must be done for each replicate 
+  if (verbose)
+    message("computing catch for each replicate...") 
+  if (verbose) 
+    msy:::loader(0)
+  for(i in 1:dms$iter){ # note: this takes a while... check with Simon if implementation is correct
+    iter(catch.n(stk.win), i) <- iter(computeCatch(stk.win, slot = "n"),i)
+    msy:::loader(i/dms$iter)
+  }
 
   catch <- matrix(FLCore::catch.n(stk.winsel), ncol = slyr2 - slyr1 + 1)
   sel <- matrix(FLCore::harvest(stk.winsel), ncol = slyr2 - slyr1 + 1)

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -481,8 +481,15 @@ eqsim_run <- function(fit,
       Ny[1,j,] <- allrecs[select]
 
       # calculate ssb now we have the recruiting age class abundance
-      ssby[j, ] <- apply(array(Mat[, rsam[j,]] * Ny[,j,] * west[, rsam[j,]] / exp(Zpre), c(ages, Nmod)), 2, sum)
-
+      Mats <- wests <- Ms <- matrix(0, nrow = dms$age, ncol = Nmod)
+      
+      for (iter in 1:dms$iter){
+        Mats[,iter] <- Mat[, rsam[j,iter],iter]
+        wests[,iter] <- west[, rsam[j,iter],iter]
+      }
+      
+      ssby[j, ] <- apply(array(Mats * Ny[,j,] * wests / exp(Zpre), c(ages, Nmod)), 2, sum)
+      
       # calculate catch.n (should this be j-1?  does it matter?)
       Cy[, j, ] <- Ny[, j-1, ] * Fy[, j-1, ] / (Fy[, j-1, ] + M[, rsam[j-1,]]) * (1 - exp(-Fy[, j-1, ] - M[, rsam[j-1,]]))
     }

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -215,9 +215,9 @@ eqsim_run <- function(fit,
     msy:::loader(i/dms$iter)
   }
 
-  catch <- matrix(FLCore::catch.n(stk.winsel), ncol = slyr2 - slyr1 + 1)
-  sel <- matrix(FLCore::harvest(stk.winsel), ncol = slyr2 - slyr1 + 1)
-  Fbar <- matrix(FLCore::fbar(stk.winsel), ncol = slyr2 - slyr1  + 1)
+  catch <- array(FLCore::catch.n(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))  
+  sel <- array(FLCore::harvest(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter)) 
+  Fbar <- array(FLCore::fbar(stk.win), dim = c(1, btyr2 - btyr1 + 1, dms$iter)) 
   sel <- sweep(sel, 2, Fbar, "/")
 
   if (sel.const == TRUE) { # take means of selection

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -372,7 +372,10 @@ eqsim_run <- function(fit,
     Ny[,1,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))
 
     # calculate ssb in first year using a different stock.wt and Mat selection and M for each simulation
-    ssby[1,] <- colSums(Mat[,rsam[1,]] * Ny[,1,] * west[,rsam[1,]] / exp(Zpre))
+    for(iter in 1:dms$iter){
+      ssby[1,] <- colSums(Mat[,rsam[1,],iter] * Ny[,1,] * west[,rsam[1,],iter] / exp(Zpre[,iter]))
+    }
+    # TODO: Check if above is correct: replicate specific SSB calculation 
 
     # if rec recruiting year class comes from previous years ssb, as in fish recruiting
     # at age 2 or winter ring herring ageing then run some more initial years

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -230,11 +230,13 @@ eqsim_run <- function(fit,
 
   # 22.2.2014 Added weight of landings per comment from Carmen
   if (bio.const==TRUE){ # take means of wts Mat and M and ratio of landings to catch
-    west[] <- apply(west, 1, mean)
-    weca[] <- apply(weca, 1, mean)
-    wela[] <- apply(wela, 1, mean)
-    Mat[] <- apply(Mat, 1, mean)
-    M[] <- apply(M, 1, mean) #me
+    for(i in 1:dms$iter){
+      west[,,i][] <- apply(west[,,i], 1, mean)
+      weca[,,i][] <- apply(weca[,,i], 1, mean)
+      wela[,,i][] <- apply(wela[,,i], 1, mean)
+      Mat[,,i][] <- apply(Mat[,,i], 1, mean)
+      M[,,i][] <- apply(M[,,i], 1, mean)
+    }
   }
   land.cat= landings / catch  # ratio of number of landings to catch
 

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -190,18 +190,18 @@ eqsim_run <- function(fit,
     return(x)
   }
 
-  west <- matrix(FLCore::stock.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  west <- array(FLCore::stock.wt(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
   i <- west == 0
   if(any(i)) west <- littleHelper(west,i)
-  weca <- matrix(FLCore::catch.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  weca <- array(FLCore::catch.wt(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter)) 
   i <- weca == 0
   if(any(i)) weca <- littleHelper(weca,i)
-  wela <- matrix(FLCore::landings.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  wela <- array(FLCore::landings.wt(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
   if(any(i)) wela <- littleHelper(wela,i)
 
-  Mat <- matrix(FLCore::mat(stk.win), ncol = btyr2 - btyr1 + 1)
-  M <- matrix(FLCore::m(stk.win), ncol = btyr2 - btyr1 + 1)
-  landings <- matrix(FLCore::landings.n(stk.winsel), ncol = slyr2 - slyr1 + 1)
+  Mat <- array(FLCore::mat(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter)) 
+  M <- array(FLCore::m(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
+  landings <- array(FLCore::landings.n(stk.win), dim = c(dms$age, btyr2 - btyr1 + 1, dms$iter))
   # if zero, use 0.10 of minimum value
 
   catch <- matrix(FLCore::catch.n(stk.winsel), ncol = slyr2 - slyr1 + 1)

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -185,7 +185,7 @@ eqsim_run <- function(fit,
   littleHelper <- function(x,i) {
     x2 <- x
     x2[i] <- NA
-    x2[] <- apply(x2,1,mean,na.rm=TRUE)
+    x2[] <- apply(x2,c(1,3), mean, na.rm = TRUE)
     x[i] <- x2[i]
     return(x)
   }

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -359,8 +359,14 @@ eqsim_run <- function(fit,
       
     }
     Zcum <- apply(Ztot, 2, function(x) c(0, cumsum(x)))
-    # create initial population structure
-    N1 <- R * exp(- unname(Zcum))
+    # create initial population structure for each replicate
+    N1 <- matrix(0, nrow = keep, ncol = Nmod)
+    
+    for (iter in 1:dms$iter){
+      N1[,iter] <- R[,iter] * exp(-unname(Zcum[,iter])) 
+    }
+    # note: slight numerical differences occur setting up population structure
+    # this way vs old EqSim. Needs to be explored but shouldn't affect ref points
 
     # set up age structure out to age 50 in first years for all simulations
     Ny[,1,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))

--- a/R/eqsim_run_iters.R
+++ b/R/eqsim_run_iters.R
@@ -1,0 +1,656 @@
+#' Simulates the Equilibrium Results for a Population.
+#'
+#' Simulate a fish stock forward in time given biological parameters, fishery
+#' parameters and advice parameters.
+#'
+#' @param fit A list returned from the function fitModels
+#' @param bio.years The years to sample maturity, weights and M from, given as
+#'                  a vector of length 2, i.e. c(2010, 2015) select from the
+#'                  years 2010 to 2015 inclusive.
+#' @param bio.const A flag (default FALSE), if TRUE mean of the biological values from the
+#'                  years selected are used
+#' @param sel.years The years to sample the selection patterns from, given as
+#'                  a vector of length 2, i.e. c(2010, 2015) select from the
+#'                  years 2010 to 2015 inclusive.
+#' @param sel.const A flag (default FALSE), if TRUE mean of the selection patterns from the
+#'                  years selected are used
+#' @param Fscan F values to scan over, i.e. seq(0, 2, by = 0.05)
+#' @param Fcv Assessment error in the advisory year
+#' @param Fphi Autocorrelation in assessment error in the advisory year
+#' @param SSBcv Spawning stock biomass error in the advisory year
+#' @param rhologRec A flag for recruitment autocorrelation, default (TRUE), or a
+#'                  vector of numeric values specifcying the autocorrelation
+#'                  parameter for the residuals for each SR model.
+#' @param Blim SSB limit reference point
+#' @param Bpa SSB precuationary reference point
+#' @param recruitment.trim A numeric vector with two log-value clipping the
+#'        extreme recruitment values from a continuous lognormal distribution.
+#'        The values must be set as c("high","low").
+#' @param Btrigger If other than 0 (default) the target F applied is reduced by
+#'                 SSB/Btrigger. This is the "ICES Advice Rule".
+#' @param Nrun The number of years to run in total (the last 50 years from that
+#'             will be retained to compute equilibrium values from)
+#' @param process.error Use stochastic recruitment or mean recruitment?
+#'                      TRUE (default) uses the predictive distribution of recruitment,
+#'                      model estimate of recruitment + simulated observation
+#'                      error.  FALSE uses model prediction of recruitment with
+#'                      no observation error.
+#' @param verbose Flag, if TRUE (default) indication of the progress of the
+#'        simulation is provided in the console. Useful to turn to FALSE when
+#'        knitting documents.
+#' @param extreme.trim a pair of quantiles (low, high) which are used to trim
+#'                     the equilibrium catch values, across simulations within
+#'                     an F scenario, when calculating the mean catch and
+#'                     landings for that F scenario.  These mean values
+#'                     calculated accross simulations within an F scenario
+#'                     are used to find which F scenario gave the maximum catch.
+#'                     \code{extreme.trim} can therefore be used to stablise the
+#'                     estimate of mean equilibrium catch and landings by F
+#'                     scenario.  The default is c(0, 1) which includes all the
+#'                     data and is effectively an untrimmed mean.
+#' @param R.initial Initial recruitment for the simulations.  This is common
+#'                  accross all simulations. Default = mean of all recruitments
+#'                  in the series.
+#' @param keep.sims Flag, if TRUE returns a matrix of population tragectories
+#'                  for each value of F in Fscan (see examples).
+#' @return
+#' A list containing the results from the forward simulation and the reference
+#' points calculated from it.
+#'
+#' @details
+#' Details of the steps required to evaluate reference points are given in
+#' ICES (2017).  WHile, details of the calculation of MSY ranges is given in
+#' ICES (2015).
+#'
+#' @references
+#' ICES (2015) Report of the Workshop to consider F MSY ranges for stocks in
+#' ICES categories 1 and 2 in Western Waters (WKMSYREF4).
+#' \href{http://ices.dk/sites/pub/Publication\%20Reports/Expert\%20Group\%20Report/acom/2015/WKMSYREF4/01\%20WKMSYREF4\%20Report.pdf}{01
+#' WKMSYREF4 Report.pdf}
+#'
+#' ICES (2017) ICES fisheries management reference points for category 1 and 2
+#' stocks.
+#' DOI: \href{https://doi.org/10.17895/ices.pub.3036}{10.17895/ices.pub.3036}
+#'
+#' @seealso
+#'
+#' \code{\link{eqsr_fit}} fits multiple stock recruitment models to a data set.
+#'
+#' \code{\link{eqsr_plot}} plots the results from eqsr_fit.
+#'
+#' \code{\link{eqsim_plot}} summary plot of the forward simulation showing estimates
+#'   of various reference points.
+#'
+#' \code{\link{eqsim_plot_range}} summary plots of the forward simulation showing
+#'   the estimates of MSY ranges (ICES, 2015)
+#'
+#' \code{\link{msy-package}} gives an overview of the package.
+#'
+#' @examples
+#' \dontrun{
+#' data(icesStocks)
+#' FIT <- eqsr_fit(icesStocks$saiNS,
+#'                 nsamp = 1000,
+#'                 models = c("Ricker", "Segreg"))
+#' SIM <-
+#'   eqsim_run(
+#'     FIT,
+#'     bio.years = c(2004, 2013),
+#'     sel.years = c(2004, 2013),
+#'     Fcv = 0.24,
+#'     Fphi = 0.42,
+#'     Blim = 106000,
+#'     Bpa = 200000,
+#'     Fscan = seq(0, 1.2, len = 40)
+#'    )
+#'
+#' # extract tragectories
+#' ssbsim <- SIM$rbya$ssb
+#' years <- SIM$rbya$simyears
+#' models <- SIM$rbya$srmodels$model
+#' Ftarget <- SIM$rbya$Ftarget
+#'
+#' Fval <- which(Ftarget == 0)
+#' Fval <- which(Ftarget > .3)[1]
+#' x <- ssbsim[Fval,,]
+#' df <- data.frame(year = 1:nrow(x),
+#'                  ssb = c(x),
+#'                  sim = rep(1:ncol(x), each = nrow(x)),
+#'                  model = rep(models, each = nrow(x)))
+#' xyplot(ssb ~ year | model, groups = sim, data = df, type = "l", col = grey(0.5, alpha = 0.5))
+#'
+#' fit <- density(x[x>1e-3], from = 0)
+#' plot(fit$x,fit$y*mean(x>1e-3),col="red", type = "l")
+#' lines(x = 0, y = mean(x<=1e-3), type = "h", lwd = 3)
+
+#'
+#' }
+#'
+#' @export
+eqsim_run <- function(fit,
+                      bio.years = c(-5, -1) + FLCore::dims(fit$stk)$maxyear, # years sample weights, M and mat
+                      bio.const = FALSE,
+                      sel.years= c(-5, -1) + FLCore::dims(fit$stk)$maxyear, # years sample sel and discard proportion by number from
+                      sel.const = FALSE,
+                      Fscan = seq(0, 2, len = 40), # F values to scan over
+                      Fcv = 0,
+                      Fphi = 0,
+                      SSBcv = 0,
+                      rhologRec = TRUE,
+                      Blim,
+                      Bpa,
+                      recruitment.trim = c(3, -3),
+                      Btrigger = 0,
+                      Nrun = 200, # number of years to run in total
+                      process.error = TRUE, # use predictive recruitment or mean recruitment? (TRUE = predictive)
+                      verbose = TRUE,
+                      extreme.trim = c(0, 1),
+                      R.initial = mean(fit$rby$rec),
+                      keep.sims = FALSE)
+{
+
+  if (abs(Fphi) >= 1) stop("Fphi, the autocorelation parameter for log F should be between (-1, 1)")
+  if (diff(recruitment.trim) > 0) stop("recruitment truncation must be given as c(high, low)")
+  # commented out as above line is a better check
+  # if ((recruitment.trim[1] + recruitment.trim[2]) > 0) stop("recruitment truncation must be between a high - low range")
+
+  if (verbose) icesTAF::msg("Setting up...")
+
+  if (length(bio.years) > 2)
+    stop("bio.years must be given as a length two vector: c(first, last)")
+  if (length(sel.years) > 2)
+    stop("sel.years must be given as a length two vector: c(first, last)")
+
+  btyr1 <- bio.years[1]
+  btyr2 <- bio.years[2]
+  slyr1 <- sel.years[1]
+  slyr2 <- sel.years[2]
+  # Keep at most 50 simulation years (which will be the last 50 of the Nrun
+  #  forward simulated years)
+  keep <- min(Nrun, 50)
+
+  SR.det <- fit$sr.det[which.max(fit$sr.det$prop),] # SR fit to iter 1 (best fit)
+  SR.sto <- fit$sr.sto # SR fits to uncertainty (i.e. assessment replicates 2+)
+  SR.det <- data.frame(a = SR.det$a, b = SR.det$b, cv = SR.det$cv, model = SR.det$model, iter = 1 )
+  SR <- rbind(SR.det, SR.sto)
+  data <- fit$rby[,c("rec","ssb","year", "iter")]
+  stk <- fit$stk
+  dms <- FLCore::dims(stk) # for array building/looping
+
+  # forecast settings (mean wt etc)
+  stk.win <- FLCore::window(stk, start = btyr1, end = btyr2)
+  stk.winsel <- FLCore::window(stk, start = slyr1  , end = slyr2)
+
+  littleHelper <- function(x,i) {
+    x2 <- x
+    x2[i] <- NA
+    x2[] <- apply(x2,1,mean,na.rm=TRUE)
+    x[i] <- x2[i]
+    return(x)
+  }
+
+  west <- matrix(FLCore::stock.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  i <- west == 0
+  if(any(i)) west <- littleHelper(west,i)
+  weca <- matrix(FLCore::catch.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  i <- weca == 0
+  if(any(i)) weca <- littleHelper(weca,i)
+  wela <- matrix(FLCore::landings.wt(stk.win), ncol = btyr2 - btyr1 + 1)
+  if(any(i)) wela <- littleHelper(wela,i)
+
+  Mat <- matrix(FLCore::mat(stk.win), ncol = btyr2 - btyr1 + 1)
+  M <- matrix(FLCore::m(stk.win), ncol = btyr2 - btyr1 + 1)
+  landings <- matrix(FLCore::landings.n(stk.winsel), ncol = slyr2 - slyr1 + 1)
+  # if zero, use 0.10 of minimum value
+
+  catch <- matrix(FLCore::catch.n(stk.winsel), ncol = slyr2 - slyr1 + 1)
+  sel <- matrix(FLCore::harvest(stk.winsel), ncol = slyr2 - slyr1 + 1)
+  Fbar <- matrix(FLCore::fbar(stk.winsel), ncol = slyr2 - slyr1  + 1)
+  sel <- sweep(sel, 2, Fbar, "/")
+
+  if (sel.const == TRUE) { # take means of selection
+    sel[] <- apply(sel, 1, mean)
+    landings[]  <- apply(landings, 1, mean)
+    catch[]  <- apply(catch, 1, mean)
+  }
+
+  # 22.2.2014 Added weight of landings per comment from Carmen
+  if (bio.const==TRUE){ # take means of wts Mat and M and ratio of landings to catch
+    west[] <- apply(west, 1, mean)
+    weca[] <- apply(weca, 1, mean)
+    wela[] <- apply(wela, 1, mean)
+    Mat[] <- apply(Mat, 1, mean)
+    M[] <- apply(M, 1, mean) #me
+  }
+  land.cat= landings / catch  # ratio of number of landings to catch
+
+  # TODO: Check if this is sensible
+  i <- is.na(land.cat)
+  if(any(i)) land.cat[i] <- 1
+
+  Fprop <- apply(FLCore::harvest.spwn(stk.winsel), 1, mean)[drop=TRUE] # vmean(harvest.spwn(stk.win))
+  Mprop <- apply(FLCore::m.spwn(stk.win), 1, mean)[drop=TRUE] # mean(m.spwn(stk.win))
+
+  # get ready for the simulations
+  Nmod <- nrow(SR)
+  NF <- length(Fscan)
+  ages <- FLCore::dims(stk)$age
+  ssb_lag <- fit$rby$ssb_lag[1]
+
+  ssby <- Ferr <- array(0, c(Nrun,Nmod),dimnames=list(year=1:Nrun,iter=1:Nmod))
+  Ny <- Fy <- WSy <- WCy <- Cy <- Wy <- Wl <- Ry <-
+    array(0, c(ages, Nrun, Nmod),
+          dimnames = list(age = (range(stk)[1]:range(stk)[2]),
+                          year = 1:Nrun,
+                          iter = 1:Nmod))
+  # TODO per note from Carmen:
+  #  NOTE: If we want Ferr to be a stationary AR(1) process, it would make
+  #        more sense to initialise Ferr as a Normal dist with zero mean and
+  #        standard deviation of AR(1) marginal distribution, i.e. standard
+  #        deviation of initial Ferr = Fcv/sqrt(1- Fphi^2), instead of just
+  #        initialising Ferr=0
+  #  2014-03-12: Changed per note form Carmen/John
+  Ferr[1,] <- stats::rnorm(n=Nmod, mean=0, sd=1)*Fcv/sqrt(1-Fphi^2)
+  for(j in 2:Nrun)
+    Ferr[j,] <- Fphi * Ferr[j-1,] + Fcv * stats::rnorm(n = Nmod, mean = 0, sd = 1)
+
+  # 2014-03-12: Changed per note form Carmen/John
+  #  Errors in SSB: this is used when the ICES MSY HCR is applied for F
+  SSBerr <- matrix(stats::rnorm(n = Nrun * Nmod, mean = 0, sd = 1), ncol = Nmod) * SSBcv
+
+  rsam <- array(sample(1:ncol(weca), Nrun * Nmod, TRUE), c(Nrun, Nmod))
+  rsamsel <- array(sample(1:ncol(sel), Nrun * Nmod, TRUE), c(Nrun, Nmod))
+  Wy[] <- c(weca[, c(rsam)])
+  Wl[] <- c(wela[, c(rsam)])
+  Ry[]  <- c(land.cat[, c(rsamsel)])
+
+  # initial recruitment
+  R <- R.initial
+
+  # set up arrays to contain simulations
+  ssbs <- cats <- lans <- recs <- array(0, c(7, NF))
+  ferr <- ssbsa <- catsa <- lansa <- recsa <- array(0, c(NF, keep, Nmod))
+  if (keep.sims) {
+    # keep all ssbs
+    ssbsall <- catsall <- lansall <- recsall <- array(0, c(NF, Nrun, Nmod))
+  }
+  begin <- Nrun - keep + 1
+
+  # New from Simmonds' 29.1.2014
+  #   Residuals of SR fits (1 value per SR fit and per simulation year
+  #     but the same residual value for all Fscan values):
+  resids= array(stats::rnorm(Nmod*(Nrun+1), 0, SR$cv),c(Nmod, Nrun+1))
+
+  # 2014-03-12: Changed per note form Carmen/John
+  #  Autocorrelation in Recruitment Residuals:
+  if(rhologRec==TRUE){
+    fittedlogRec <-  do.call(cbind, lapply( c(1:nrow(fit$sr.sto)), function(i){
+      FUN <- match.fun(fit$sr.sto$model[i])
+      FUN(fit$sr.sto[i, ], fit$rby$ssb) } )  )
+    # Calculate lag 1 autocorrelation of residuals:
+    rhologRec <- apply(log(fit$rby$rec)-fittedlogRec, 2, function(x){stats::cor(x[-length(x)],x[-1])})
+  }
+  if (is.numeric(rhologRec)) {
+    # Draw residuals according to AR(1) process:
+    for(j in 2:(Nrun+1)){ resids[,j] <- rhologRec * resids[,j-1] + resids[,j]*sqrt(1 - rhologRec^2) }
+  }
+
+
+  # Limit how extreme the Rec residuals can get:
+  lims = t(array(SR$cv,c(Nmod,2))) * recruitment.trim
+  for (k in 1:Nmod) { resids[k,resids[k,]>lims[1,k]]=lims[1,k]}
+  for (k in 1:Nmod) { resids[k,resids[k,]<lims[2,k]]=lims[2,k]}
+  # end New from Simmonds 29.1.2014
+
+  if (verbose) icesTAF::msg("Running forward simulations.")
+  if (verbose) loader(0)
+
+  # Looping over each F value in Fscan. For each of the Nmod SR fits
+  # (replicates), do a forward simulation during Nrun years
+  # There are Rec residuals for each SR fit and year, which take the same
+  # values for all Fscan
+  for (i in 1:NF) {
+    # The F value to test
+    Fbar <- Fscan[i]
+
+    ############################################################################
+    # Population in simulation year 1:
+
+    # Zpre: Z that occurs before spawning
+    Zpre <- Fbar * sel[,rsamsel[1,]] * Fprop + M[,rsam[1,]] * Mprop
+
+    # Zpos: Z that occurs after spawning
+    # Zpos not used anywhere
+    Zpos <- Fbar * (1-Fprop) * sel[,rsamsel[1,]] + M[,rsam[1,]] * (1-Mprop)
+
+    # run Z out to age 50 for plus group...
+    # TODO:
+    # Comments from Carmen: Zcum is a cumulative sum:
+    #  There is a matrix of F-at-age and a matrix of M-at-age (each has 49 ages, Nmod replicates)
+    #  The F and M matrices are summed, giving Z-at-age (49 ages, Nmod replicates)
+    Ztot <- Fbar * sel[c(1:ages, rep(ages, 49 - ages)), rsamsel[1,]] + M[c(1:ages, rep(ages, 49 - ages)), rsam[1,]]
+    Zcum <- apply(Ztot, 2, function(x) c(0, cumsum(x)))
+    # create initial population structure
+    N1 <- R * exp(- unname(Zcum))
+
+    # set up age structure out to age 50 in first years for all simulations
+    Ny[,1,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))
+
+    # calculate ssb in first year using a different stock.wt and Mat selection and M for each simulation
+    ssby[1,] <- colSums(Mat[,rsam[1,]] * Ny[,1,] * west[,rsam[1,]] / exp(Zpre))
+
+    # if rec recruiting year class comes from previous years ssb, as in fish recruiting
+    # at age 2 or winter ring herring ageing then run some more initial years
+    # using the same intial population
+    # - NOTE roll forward one year incase ssb_lag is 0 so that we always have a year j-1.
+    for (j in 2:pmax(2, ssb_lag + 2)) {
+      Ny[,j,] <- rbind(N1[1:(ages-1),], colSums(N1[ages:50,]))
+      ssby[j,] <- colSums(Mat[,rsam[j-1,]] * Ny[,1,] * west[,rsam[j-1,]] / exp(Zpre))
+    }
+
+    # Years (2 + ssb_lag) to Nrun:
+    for (j in (2+ssb_lag):Nrun) {
+
+      #  year j is the projection year,
+      #  year j-1 is where fishing is going to take place
+      #  conceptually the assessment takes place in year j-2
+
+      # apply HCR
+      # (intended) Fbar to be applied in year j-1 (depends on SSB in year j-1):
+      # 2014-03-12: Changed per note form Carmen/John
+      # Fnext <- Fbar * pmin(1, SSB/Btrigger)
+      Fnext <- Fbar * pmin(1, ssby[j-1,] * exp(SSBerr[j-1,]) / Btrigger)
+
+      # apply some noise to the F
+      # Notes from Carmen:
+      #  Assessment and/or implementation error (modifies intended F to get
+      #  realised F)
+      #  Error: AR(1) process on log(F) with autocorrel = Fphi, and
+      #  conditional stand deviation = Fcv
+      #  Might make more sense to have the "Ferr" matrix calculated before
+      #  the Fscan loop starts so that the same errors in F are applied to
+      #  all Fscan values ???? (as for Rec residuals)
+
+      # Outcommented 2014-03-12 because F-error already been drawn outside the
+      #   loop, so this line here is no longer needed:
+      # Ferr[j,] <- Fphi * Ferr[j-1,] + rnorm(Nmod, 0, Fcv)
+
+      # realised Fbar in year j-1:
+      Fnext <- exp(Ferr[j,]) * Fnext
+
+      # get a selection pattern for each simulation and apply this to get N
+      Zpre <- rep(Fnext, each = length(Fprop)) * Fprop * sel[, rsamsel[j-1,]] + M[, rsam[j-1,]] * Mprop
+
+      # get Fy
+      Fy[ , j-1, ] <- rep(Fnext, each = ages) * sel[, rsamsel[j-1,]]
+
+      # roll population one year forward having decided in the F value
+      Ny[ -1, j, ] <- Ny[1:(ages-1), j-1, ] * exp(-Fy[1:(ages-1), j-1, ] - M[1:(ages-1), rsam[j-1,]])
+      # calculate plus group
+      Ny[ages, j, ] <- Ny[ages, j, ] + Ny[ages, j-1, ] * exp(-Fy[ages, j-1, ] - M[ages, rsam[j-1,]])
+
+      if (ssb_lag == 0) {
+        # calculate ssb ignores contribution of recruiting age 0 fish
+        ssby[j, ] <- apply(array(Mat[, rsam[j,]] * Ny[,j,] * west[, rsam[j,]] / exp(Zpre), c(ages, Nmod)), 2, sum)
+      }
+
+      # simulate recruitment in year j
+      # get ssb from appropriate year, if ssb_lag is zero, then current year ssb is used
+      SSBforRec <- ssby[j-ssb_lag,]
+
+      # predict recruitment using various models
+      if (process.error) {
+        # Changes 29.1.2014
+        # new random draws each time
+        # allrecs <- sapply(unique(SR $ mod), function(mod) exp(match.fun(mod) (SR, SSB) + rnorm(Nmod, 0, SR $ cv)))
+        # same random draws used for each F
+        ###### 2014-03-13  TMP COMMENT - ERROR OCCURS HERE
+        allrecs <- sapply(unique(SR$mod), function(mod) exp(match.fun(mod)(SR, SSBforRec) + resids[,j]))
+        # end Changes 29.1.2014
+      } else {
+        allrecs <- sapply(unique(SR$mod), function(mod) exp(match.fun(mod) (SR, SSBforRec)))
+      }
+
+      # Comment from Carmen:
+      #  For each of the Nmod replicates, this selects the appropriate SR model
+      #   type to use in that replicate
+      #  Note that the order of SR model types that comes out in "select" is
+      #   not necessarily the same order in which the SR model types were
+      #   entered as inputs -- I presume the **next 2 lines** of code have
+      #   been checked to avoid potential bugs due to this reordering  ????
+      select <- cbind(seq(Nmod), as.numeric(factor(SR$mod, levels = unique(SR$mod))))
+      Ny[1,j,] <- allrecs[select]
+
+      # calculate ssb now we have the recruiting age class abundance
+      ssby[j, ] <- apply(array(Mat[, rsam[j,]] * Ny[,j,] * west[, rsam[j,]] / exp(Zpre), c(ages, Nmod)), 2, sum)
+
+      # calculate catch.n (should this be j-1?  does it matter?)
+      Cy[, j, ] <- Ny[, j-1, ] * Fy[, j-1, ] / (Fy[, j-1, ] + M[, rsam[j-1,]]) * (1 - exp(-Fy[, j-1, ] - M[, rsam[j-1,]]))
+    }
+
+    # convert to catch weight
+    Cw <- Cy * Wy   # catch Numbers *catch wts
+    land <- Cy * Ry * Wl # catch Numbers * Fraction (in number) landed and landed wts
+    Lan <- apply(land, 2:3, sum)
+    Cat <- apply(Cw, 2:3, sum)
+
+    # summarise everything and spit out!
+    ferr[i, , ] <- Ferr[begin:Nrun, ]
+    ssbsa[i, , ] <- ssby[begin:Nrun, ]
+    catsa[i, , ] <- Cat[begin:Nrun, ]
+    lansa[i, , ] <- Lan[begin:Nrun, ]
+    recsa[i, , ] <- Ny[1, begin:Nrun, ]
+
+    # store quantiles
+    quants <- c(0.025, 0.05, 0.25, 0.5, 0.75, 0.95, 0.975)
+    ssbs[, i] <- stats::quantile(ssbsa[i, , ], quants)
+    cats[, i] <- stats::quantile(catsa[i, , ], quants)
+    lans[, i] <- stats::quantile(lansa[i, , ], quants)
+    recs[, i] <- stats::quantile(recsa[i, , ], quants)
+
+    # if user has requested full simulations
+    if (keep.sims) {
+      ssbsall[i, , ] <- ssby
+      catsall[i, , ] <- Cat
+      lansall[i, , ] <- Lan
+      recsall[i, , ] <- Ny[1,,]
+    }
+
+    if (verbose) loader(i/NF)
+  }
+
+  if (verbose) icesTAF::msg("Summarising simulations")
+
+  dimnames(ssbs) <- dimnames(cats) <-
+    dimnames(lans) <- dimnames(recs) <-
+    list(quants=c("p025","p05","p25","p50","p75","p95","p975"),
+         fmort=Fscan)
+
+  rbp2dataframe <- function(x,variable) {
+    x <- data.frame(t(x))
+    x$variable <- variable
+    x$Ftarget <- as.numeric(row.names(x))
+    rownames(x) <- NULL
+    return(x)
+  }
+  rbp <- rbind(rbp2dataframe(recs,"Recruitment"),
+               rbp2dataframe(ssbs,"Spawning stock biomass"),
+               rbp2dataframe(cats,"Catch"),
+               rbp2dataframe(lans,"Landings"))
+  rbp <- rbp[,c(9,8,1:7)]
+
+  # STOCK REFERENCE POINTS
+
+  FCrash05 <- Fscan[which.max(cats[2,]):NF][ which(cats[2, which.max(cats[2,]):NF] < 0.05*max(cats[2,]) )[1] ]
+  FCrash50 <- Fscan[which.max(cats[4,]):NF][ which(cats[4, which.max(cats[4,]):NF] < 0.05*max(cats[4,]) )[1] ]
+
+
+  # Einar amended 30.1.2014
+  if(missing(extreme.trim)) {
+    catm <- apply(catsa, 1, mean)
+    lanm <- apply(lansa, 1, mean)
+  } else {
+
+    # 2014-03-12 Outcommented per note from Carmen/John - see below
+    #x <- catsa
+    #i <- x > quantile(x,extreme.trim[2]) |
+    #  x < quantile(x,extreme.trim[1])
+    #x[i] <- NA
+    #catm <- apply(x, 1, mean, na.rm=TRUE)
+    #
+    #x <- lansa
+    #i <- x > quantile(x,extreme.trim[2]) |
+    #  x < quantile(x,extreme.trim[1])
+    #x[i] <- NA
+    #lanm <- apply(x, 1, mean, na.rm=TRUE)
+
+    # 2014-03-12: Above replaced with the following per note from Carmen/John
+    #  If we want to remove whole SR models, we could use the following code. But it is too extreme, it ends up getting rid of most models:
+    # auxi2 <- array( apply(catsa, 1, function(x){auxi<-rep(TRUE,Nmod); auxi[x > quantile(x, extreme.trim[2]) | x < quantile(x, extreme.trim[1])] <- FALSE; x <- auxi } ), dim=c(keep,Nmod,NF))
+    # auxi2 <- (1:Nmod)[apply(auxi2, 2, function(x){length(unique(as.vector(x)))})==1]
+    # apply(catsa[,,auxi2],1,mean)
+
+    # So I think the alternative is not to get rid of whole SR models, but of different SR models depending on the value of F:
+    catm <- apply(catsa, 1, function(x){mean(x[x <= stats::quantile(x, extreme.trim[2]) & x >= stats::quantile(x, extreme.trim[1])])})
+    lanm <- apply(lansa, 1, function(x){mean(x[x <= stats::quantile(x, extreme.trim[2]) & x >= stats::quantile(x, extreme.trim[1])])})
+  }
+
+  # end Einar amended 30.1.2014
+
+  maxcatm <- which.max(catm)
+  maxlanm <- which.max(lanm)
+
+  # Einar added 29.1.2014
+  rbp$Mean <- NA
+  rbp$Mean[rbp$variable == "Catch"] <- catm
+  rbp$Mean[rbp$variable == "Landings"] <- lanm
+  # end Einar added 29.1.2014
+
+
+  catsam <- apply(catsa, c(1,3), mean)
+  lansam <- apply(lansa, c(1,3), mean)
+  maxpf <- apply(catsam, 2, which.max)
+  maxpfl <- apply(lansam, 2, which.max)
+
+  FmsyLan <- Fscan[maxpfl]
+  msymLan <- mean(FmsyLan)
+  vcumLan <- stats::median(FmsyLan)
+  fmsy.densLan <- stats::density(FmsyLan)
+  vmodeLan <- fmsy.densLan$x[which.max(fmsy.densLan$y)]
+
+  FmsyCat <- Fscan[maxpf]
+  msymCat <- mean(FmsyCat)
+  vcumCat <- stats::median(FmsyCat)
+  fmsy.densCat <- stats::density(FmsyCat)
+  vmodeCat <- fmsy.densCat$x[which.max(fmsy.densCat$y)]
+
+  pFmsyCat  <- data.frame(Ftarget=fmsy.densCat$x,
+                          value=cumsum(fmsy.densCat$y * diff(fmsy.densCat$x)[1]),
+                          variable="pFmsyCatch")
+  pFmsyLan  <- data.frame(Ftarget=fmsy.densLan$x,
+                          value=cumsum(fmsy.densLan$y * diff(fmsy.densLan$x)[1]),
+                          variable="pFmsyLandings")
+  pProfile <- rbind(pFmsyCat,pFmsyLan)
+
+  # PA REFERENCE POINTS
+  if(!missing(Blim)) {
+    pBlim <- apply(ssbsa > Blim, 1, mean)
+
+    i <- max(which(pBlim > .95))
+    grad <- diff(Fscan[i + 0:1]) / diff(pBlim[i + 0:1])
+    flim <- Fscan[i] + grad * (0.95 - pBlim[i]) # linear interpolation i think..
+
+    i <- max(which(pBlim > .90))
+    grad <- diff(Fscan[i + 0:1]) / diff(pBlim[i + 0:1])
+    flim10 <- Fscan[i]+grad*(0.9-pBlim[i]) # linear interpolation i think..
+
+    i <- max(which(pBlim > .50))
+    grad <- diff(Fscan[i + 0:1]) / diff(pBlim[i + 0:1])
+    flim50 <- Fscan[i]+grad*(0.5-pBlim[i]) # linear interpolation i think..
+
+    pBlim <- data.frame(Ftarget = Fscan,value = 1-pBlim,variable="Blim")
+    pProfile <- rbind(pProfile,pBlim)
+  } else {
+    flim <- flim10 <- flim50 <- Blim <- NA
+  }
+
+  if(!missing(Bpa)) {
+    pBpa <- apply(ssbsa > Bpa, 1, mean)
+    pBpa <- data.frame(Ftarget = Fscan,value = 1-pBpa,variable="Bpa")
+    pProfile <- rbind(pProfile,pBpa)
+  } else {
+    Bpa <- NA
+  }
+
+  # GENERATE REF-TABLE
+  catF <- c(flim, flim10, flim50, vcumCat, Fscan[maxcatm], FCrash05, FCrash50)
+  lanF <- c(   NA,    NA,     NA, vcumLan, Fscan[maxlanm],       NA,       NA)
+  catC <- stats::approx(Fscan, cats[4,], xout = catF)$y
+  lanC <- stats::approx(Fscan, lans[4,], xout = lanF)$y
+  catB <- stats::approx(Fscan, ssbs[4,], xout = catF)$y
+  lanB <- stats::approx(Fscan, ssbs[4,], xout = lanF)$y
+
+  Refs <- rbind(catF, lanF, catC, lanC, catB, lanB)
+  rownames(Refs) <- c("catF","lanF","catch","landings","catB","lanB")
+  colnames(Refs) <- c("F05","F10","F50","medianMSY","meanMSY","FCrash05","FCrash50")
+
+  #TODO: id.sim - user specified.
+
+  # 2014-03-12 Ammendments per note from Carmen/John
+  # CALCULATIONS:
+
+  # Fmsy: value that maximises median LT catch or median LT landings
+  auxi <- stats::approx(Fscan, cats[4, ],xout=seq(min(Fscan),max(Fscan),length=200))
+  FmsyMedianC <- auxi$x[which.max(auxi$y)]
+  MSYMedianC <- max(auxi$y)
+  # Value of F that corresponds to 0.95*MSY:
+  FmsylowerMedianC <- auxi$x[ min( (1:length(auxi$y))[auxi$y/MSYMedianC >= 0.95] ) ]
+  FmsyupperMedianC <- auxi$x[ max( (1:length(auxi$y))[auxi$y/MSYMedianC >= 0.95] ) ]
+
+  auxi <- stats::approx(Fscan, lans[4, ],xout=seq(min(Fscan),max(Fscan),length=200))
+  FmsyMedianL <- auxi$x[which.max(auxi$y)]
+  MSYMedianL <- max(auxi$y)
+
+  # Value of F that corresponds to 0.95*MSY:
+  FmsylowerMedianL <- auxi$x[ min( (1:length(auxi$y))[auxi$y/MSYMedianL >= 0.95] ) ]
+  FmsyupperMedianL <- auxi$x[ max( (1:length(auxi$y))[auxi$y/MSYMedianL >= 0.95] ) ]
+
+  F5percRiskBlim <- flim
+
+  refs_interval <- data.frame(FmsyMedianC = FmsyMedianC,
+                             FmsylowerMedianC = FmsylowerMedianC,
+                             FmsyupperMedianC = FmsyupperMedianC,
+                             FmsyMedianL = FmsyMedianL,
+                             FmsylowerMedianL = FmsylowerMedianL,
+                             FmsyupperMedianL = FmsyupperMedianL,
+                             F5percRiskBlim = F5percRiskBlim,
+                             Btrigger = Btrigger)
+
+  # END 2014-03-12 Ammendments per note from Carmen/John
+
+  sim <- list(ibya=list(Mat = Mat, M = M, Fprop = Fprop, Mprop = Mprop,
+                        west = west, weca = weca, sel = sel),
+              rbya=list(ferr = ferr, ssb = ssbsa, catch = catsa,
+                        landings = lansa, rec = recsa,
+                        srmodels = SR, Ftarget = Fscan, simyears = begin:Nrun),
+              rby=fit$rby,
+              rbp=rbp,
+              Blim=Blim,
+              Bpa=Bpa,
+              Refs = Refs,
+              pProfile=pProfile,
+              id.sim=fit$id.sr,
+              refs_interval=refs_interval,
+              rhologRec = rhologRec)
+
+  if (keep.sims) {
+    sim$rbya_all <- list(ssb=ssbsall, catch = catsall, landings = lansall, rec = recsall)
+  }
+
+  if (verbose) icesTAF::msg("Calculating MSY range values")
+
+  sim <- eqsim_range(sim)
+
+  return(sim)
+
+}

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -80,7 +80,7 @@
 #' }
 #'
 #' @export
-eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"),
+eqsr_fit_iters <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"),
                      id.sr = FLCore::name(stk), remove.years = NULL, rshift = 0, verbose = TRUE)
 {
   # some checks on the model argument

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -117,7 +117,9 @@ eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","S
                fbar = c(FLCore::fbar(stk)),
                landings = c(FLCore::landings(stk)),
                catch = c(FLCore::catch(stk)),
-               ssb_lag = ssb_lag)
+               ssb_lag = ssb_lag,
+               iter = rep(1:dms$iter, times = 1, length.out = NA, each = dms$year)
+               )
 
   # remove years with NA recruitment
   data <- data[stats::complete.cases(data),]

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -135,9 +135,9 @@ eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","S
   }
 
   # run model averaging
-  srfit <- eqsr_Buckland(data[!data$remove.years,c("year", "rec", "ssb")],
-                         nsamp,
-                         models)
+  srfit <- eqsr_uncertainty_iters(data[!data$remove.years,c("year", "rec", "ssb", "iter")],
+                                  nsamp,
+                                  models)
 
   # create output object
   out <- c(srfit, list(stk = stk, rby = data, id.sr = id.sr))

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -98,11 +98,14 @@ eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","S
   # get correct recruitment vector for each SSB
   # dims$min is the minimum age => recruitment age
   dms <- FLCore::dims(stk)
-  rec <- c(FLCore::rec(stk))
-  ssb_lag <- dms$min + rshift
-  if (ssb_lag > 0)
-  {
-    rec <- c(rec[-seq(ssb_lag)], rep(NA, ssb_lag))
+  ssb_lag <- dms$min + rshift 
+  if (ssb_lag > 0){
+    rec <- FLCore::rec(stk)
+    rec[,ac(dms$minyear:(dms$maxyear - ssb_lag))] <- rec[,ac((dms$minyear + ssb_lag):dms$maxyear)] # backshift recruitment
+    rec[,ac((dms$maxyear - ssb_lag + 1):dms$maxyear)] <- NA # overwrite terminal recruitment values
+    rec <- c(rec) 
+  } else {
+    rec <- c(FLCore::rec(stk))
   }
 
   # combine all required data together

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -80,7 +80,7 @@
 #' }
 #'
 #' @export
-eqsr_fit <- function(stk, nsamp = 1000, models = c("Ricker","Segreg","Bevholt"),
+eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"),
                      id.sr = FLCore::name(stk), remove.years = NULL, rshift = 0)
 {
   # some checks on the model argument

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -81,7 +81,7 @@
 #'
 #' @export
 eqsr_fit <- function(stk, nsamp = FLCore::dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"),
-                     id.sr = FLCore::name(stk), remove.years = NULL, rshift = 0)
+                     id.sr = FLCore::name(stk), remove.years = NULL, rshift = 0, verbose = TRUE)
 {
   # some checks on the model argument
   if (!is.character(models)) stop("models arg should be character vector giving names of stock recruit models")

--- a/R/eqsr_fit_iters.R
+++ b/R/eqsr_fit_iters.R
@@ -1,0 +1,142 @@
+#' Stock recruitment fitting
+#'
+#' Fits one or more stock recruitment relationship to data containted in an
+#' FLStock object. If more than one stock recruit relationship is provided, the
+#' models are weighted based on smooth AIC weighting (See Buckland et al., 1997).
+#'
+#' @param stk FLStock object
+#' @param nsamp Number of samples (iterations) to take from the stock recruitment
+#'              fit (default is 1000).  If 0 (zero) then only the fits to the
+#'              data are returned and no simulations are made.
+#' @param models A character vector containing stock recruitment models to use
+#'               in the model averaging. User can set any combination of
+#'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
+#' @param id.sr A character vector specifying an id or name for the stock
+#'              recruitment fit being run. The default is to use the slot "name"
+#'              in the stk parameter is provided
+#' @param remove.years A vector specifying the years to remove from the model
+#'                     fitting.
+#' @param rshift lag ssb by aditional years (default = 0).  As an example, for
+#'   some herring stocks, age 1 (1 winter ring) fish were spawned 2 years
+#'   previously, in this case, rshift = 1.
+#' @return A list containing the following objects:
+#' \itemize{
+#'   \item `sr.sto` data.frame containing the alpha (a), beta (b), cv and model
+#'         names. The number of rows correspond to the value set of `nsamp` in
+#'         the function call.
+#'   \item `sr.det` The parameters in the stock recruitment model corresponding
+#'         to the "best fit" of any given model.
+#'   \item `stk` An FLStock object, same as provided as input by the user.
+#'   \item `rby` A data.frame containing the recruitment (rec), spawning stock
+#'         biomass (ssb) and year used in the fitting of the data.
+#'   \item `id.sr` A string containing run name (taken from the `id.sr` argument)
+#' }
+#'
+#' @references
+#'
+#' Buckland, S.T., K.P. Burnham & N.H. Augustin (1997). Model selection: An integral part of inference.
+#' Biometrics 53, 603-618.
+#' DOI: \href{https://doi.org/10.2307/2533961}{10.2307/2533961}
+#'
+#' @seealso
+#' \code{\link{eqsr_plot}} plots a simulation of predictive recruitment
+#' from the fit, and shows a summary of the contributions of each stock
+#' recruitment model to the model average fit.
+#'
+#' @examples
+#' data(icesStocks)
+#' FIT <- eqsr_fit(icesStocks$saiNS,
+#'                 nsamp = 0,
+#'                 models = c("Ricker", "Segreg"))
+#'
+#' # summary of individual fits
+#' FIT$sr.det
+#' eqsr_plot(FIT)
+#'
+#' # fit a bounded segmented regression
+#' Segreg_bounded  <- function(ab, ssb) {
+#'   ab$b <- min_ssb + ab$b
+#'   Segreg(ab, ssb)
+#' }
+#' min_ssb <- min(FLCore::ssb(icesStocks$saiNS))
+#'
+#' FIT <- eqsr_fit(icesStocks$saiNS,
+#'                 nsamp = 0,
+#'                 models = c("Segreg", "Segreg_bounded"))
+#'
+#' # summary of individual fits
+#' FIT$sr.det
+#' FIT$sr.det$b[2] + min_ssb
+#' eqsr_plot(FIT)
+#'
+#' \dontrun{
+#' FIT <- eqsr_fit(icesStocks$saiNS,
+#'                 nsamp = 2000,
+#'                 models = c("Segreg", "Segreg_bounded"))
+#'
+#' # summary of individual fits
+#' FIT$sr.det
+#' eqsr_plot(FIT)
+#' }
+#'
+#' @export
+eqsr_fit <- function(stk, nsamp = 1000, models = c("Ricker","Segreg","Bevholt"),
+                     id.sr = FLCore::name(stk), remove.years = NULL, rshift = 0)
+{
+  # some checks on the model argument
+  if (!is.character(models)) stop("models arg should be character vector giving names of stock recruit models")
+  if(any(models %in% c("ricker","segreg","bevholt"))) {
+    stop("Please note that the msy stock-recruitment functions have been renamed:
+   ricker -> Ricker
+   bevholt -> Bevholt
+   segreg ->  Segreg
+   smooth_hockey -> Smooth_hockey
+   This was done to resolve conflicts with same named functions in the FLCore-package.
+   ERGO: use a capital in the first letter if you want to call these functions")
+  }
+
+  # get correct recruitment vector for each SSB
+  # dims$min is the minimum age => recruitment age
+  dms <- FLCore::dims(stk)
+  rec <- c(FLCore::rec(stk))
+  ssb_lag <- dms$min + rshift
+  if (ssb_lag > 0)
+  {
+    rec <- c(rec[-seq(ssb_lag)], rep(NA, ssb_lag))
+  }
+
+  # combine all required data together
+  # note year is the year that SSB had that value
+  data <-
+    data.frame(year = with(dms, minyear:maxyear),
+               rec = rec,
+               ssb = c(FLCore::ssb(stk)),
+               fbar = c(FLCore::fbar(stk)),
+               landings = c(FLCore::landings(stk)),
+               catch = c(FLCore::catch(stk)),
+               ssb_lag = ssb_lag)
+
+  # remove years with NA recruitment
+  data <- data[stats::complete.cases(data),]
+
+  # which years to use in the fit
+  data$remove.years <- FALSE
+  if (!is.null(remove.years)) {
+    remove.years <- data$year[data$year %in% remove.years]
+    message("removing (ssb) years:\n\t",
+            paste(remove.years, collapse = ", "),
+            "\n  from the recruitment fitting procedure.")
+    data$remove.years <- data$year %in% remove.years
+  }
+
+  # run model averaging
+  srfit <- eqsr_Buckland(data[!data$remove.years,c("year", "rec", "ssb")],
+                         nsamp,
+                         models)
+
+  # create output object
+  out <- c(srfit, list(stk = stk, rby = data, id.sr = id.sr))
+  class(out) <- c("eqsr_fit", c("list", "vector"))
+
+  out
+}

--- a/R/eqsr_plot_iters.R
+++ b/R/eqsr_plot_iters.R
@@ -1,0 +1,193 @@
+globalVariables(c("rec", "year", "Model", "p05", "p95", "p50"))
+
+#' Plot Simulated Predictive Distribution of Recruitment
+#'
+#'
+#'
+#' @param fit an fitted stock recruit model returned from \code{eqsr_fit}
+#' @param n Number of random recruitment draws to plot
+#' @param x.mult max value for the y axis (ssb) as a multiplier of maximum
+#'               observed ssb
+#' @param y.mult max value for the x axis (rec) as a multiplier of maismum
+#'               observed rec
+#' @param ggPlot Flag, if FALSE (default) plot using base graphics, if TRUE
+#'               do a ggplot
+#' @param Scale Numeric value for scaling varibles in plot.
+#'
+#' @return NULL produces a plot
+#'
+#' @seealso
+#' \code{\link{eqsr_fit}} Fits several stock recruitment models to a data set
+#' and calculates the proportion contribution of each model based on a bootstrap
+#' model averaging procedure.
+#'
+#' @examples
+#'
+#' \dontrun{
+#' data(icesStocks)
+#' FIT <- eqsr_fit(icesStocks$saiNS,
+#'                 nsamp = 1000,
+#'                 models = c("Ricker", "Segreg"))
+#'
+#' eqsr_plot(FIT, n = 20000)
+#'
+#' # Scale argument only available for ggPlot = TRUE
+#' eqsr_plot(FIT, n = 20000, ggPlot = TRUE, Scale = 1000)
+#' }
+#'
+#' @export
+eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
+                       ggPlot = FALSE, Scale = 1)
+{
+  # get the draws from the SR parameter simulations
+  modset <- fit$sr.sto
+
+  # get the full data set
+  data <- fit$rby[,c("year", "rec", "ssb")]
+
+  # set up ranges
+  minSSB <- min(data$ssb, max(data$ssb) * 0.0125)
+  maxSSB <- max(data$ssb) * x.mult
+  maxrec <- max(data$rec) * y.mult
+
+  if (!is.null(modset)) {
+    # evaluate recruitment at 100 ssb points
+    ssb_eval <- seq(minSSB, maxSSB, length.out = 100)
+    # reduce n to get n samples pairs
+    n_mods <- floor(n / 100)
+
+    # a function to sample from the predictive distribution
+    # of recruitment given a bootstrap SR fit.  Each row in modset
+    # has a (potrentially) different form, parameter estimates and residual CV.
+    sample_rec <- function(i) {
+      # what SR model are we simulting from:
+      FUN <-  match.fun(modset$model[i])
+      # simulate from _predictive_ distribrution of recruitment
+      exp( FUN(modset[i,], ssb_eval) + stats::rnorm(length(ssb_eval), sd = modset $ cv[i]) )
+    }
+
+    # (up)sample the model fits
+    ids <- sample(1:nrow(modset), n_mods, replace = TRUE)
+    rec_sim <- sapply(ids, sample_rec)
+
+    # form into a big DF
+    out <- data.frame(grp = rep(1:length(ssb_eval), n_mods),
+                      mid.grp = rep(ssb_eval, n_mods),
+                      ssb = jitter(rep(ssb_eval, n_mods), 2), # jitter for nices plotting
+                      rec = c(rec_sim),
+                      model = rep(modset[ids,"model"], each = length(ssb_eval)))
+
+    tmp <- paste(fit$sr.det$model, fit$sr.det$prop)
+    names(tmp) <- fit$sr.det$model
+    out$Model <- tmp[out$model]
+
+    # calculate smooth recruitment median and 5th and 95th percentile for plotting
+    fit50 <- mgcv::gam(rec ~ s(ssb, m = 0),
+                data = data.frame(ssb = ssb_eval, rec = apply(rec_sim, 1, stats::quantile, .50)))
+    fit05 <- mgcv::gam(rec ~ s(ssb, m = 0),
+                data = data.frame(ssb = ssb_eval, rec = apply(rec_sim, 1, stats::quantile, .05)))
+    fit95 <- mgcv::gam(rec ~ s(ssb, m = 0),
+                data = data.frame(ssb = ssb_eval, rec = apply(rec_sim, 1, stats::quantile, .95)))
+
+    Percentiles <-
+      data.frame(
+        ssb = ssb_eval,
+        p50 = stats::fitted(fit50),
+        p05 = stats::fitted(fit05),
+        p95 = stats::fitted(fit95)
+      )
+    Percentiles <- Percentiles[stats::complete.cases(Percentiles),]
+
+  }
+
+  if(!ggPlot) {
+
+    # set up plot
+    plot(0, 0, type = "n",
+         xlim = c(0, maxSSB), ylim = c(0, maxrec), las = 1,
+         xlab = "Spawning stock biomass", ylab="Recruitment",
+         main = paste("Predictive distribution of recruitment\nfor", fit$id.sr))
+
+    if (!is.null(modset)) {
+      points(out$ssb, out$rec,
+             pch = 20, cex = 1,
+             col = grDevices::grey(0, alpha = 0.02))
+
+      lines(p50 ~ ssb, col = 7, lwd = 3, data = Percentiles)
+      lines(p05 ~ ssb, col = 4, lwd = 3, data = Percentiles)
+      lines(p95 ~ ssb, col = 4, lwd = 3, data = Percentiles)
+    }
+
+    # plot the best fit for each model as a line
+    x <- fit$sr.det
+    y <- seq(1, round(maxSSB), length = 100)
+    for (i in 1:nrow(x)) {
+      lines(y, exp(match.fun(as.character(x$model[i])) (x[i,], y)), col = "black", lwd = 2, lty = i)
+    }
+
+    # plot the observation points
+    lines(data$ssb, data$rec, col = "red")
+    points(data$ssb, data$rec, pch = 19, col = "red", cex = 1.25)
+    # plot the model weights on the graph
+    for (i in 1:nrow(fit$sr.det)) {
+      text(0.2 * maxSSB,
+           maxrec*(1 - i/10),
+           paste(fit$sr.det$model[i], round(fit$sr.det$prop[i], 2)),
+           cex = 0.9, adj = 1)
+    }
+
+  } else { # ggplot
+    #
+    x <- fit$sr.det
+    ssb <- seq(1,round(max(maxSSB)),length=100)
+    z <- sapply(1:nrow(x), function(i) rec <- exp(match.fun(as.character(x$model[i])) (x[i,], ssb)))
+    modelLines <- as.data.frame(cbind(ssb,z))
+    names(modelLines) <- c("ssb",paste(x$model,x$prop))
+    modelLines <- reshape2::melt(modelLines,id.var="ssb",variable.name="Model",value.name="rec")
+
+    if (!is.null(modset)) {
+      out$ssb <- out$ssb/Scale
+      out$rec <- out$rec/Scale
+      out$mid.grp <- out$mid.grp/Scale
+      Percentiles$ssb <- Percentiles$ssb/Scale
+      Percentiles$p50 <- Percentiles$p50/Scale
+      Percentiles$p05 <- Percentiles$p05/Scale
+      Percentiles$p95 <- Percentiles$p95/Scale
+      i <- sample(nrow(out),n)
+    }
+    modelLines$ssb <- modelLines$ssb/Scale
+    modelLines$rec <- modelLines$rec/Scale
+
+    fit$rby$ssb <- fit$rby$ssb/Scale
+    fit$rby$rec <- fit$rby$rec/Scale
+
+    if (!is.null(modset)) {
+      ggplot2::ggplot(out[i,]) +
+        ggplot2::theme_bw() +
+        ggplot2::geom_point(ggplot2::aes(x=ssb,y=rec,colour=Model),size=1, alpha = 0.2) +
+        ggplot2::geom_line(data=Percentiles,ggplot2::aes(x=ssb,y=p05),colour="blue", lwd = 1.5) +
+        ggplot2::geom_line(data=Percentiles,ggplot2::aes(x=ssb,y=p95),colour="blue", lwd = 1.5) +
+        ggplot2::geom_line(data=Percentiles,ggplot2::aes(ssb,p50),col="yellow", lwd = 1.5) +
+        ggplot2::geom_line(data=modelLines,ggplot2::aes(ssb,rec,colour=Model),lwd=1.5) +
+        ggplot2::coord_cartesian(ylim=c(0, stats::quantile(out$rec[i],0.99))) +
+        ggplot2::geom_path(data=fit$rby, ggplot2::aes(ssb, rec), col="black",linetype=2, lwd = 1) +
+        ggplot2::geom_text(data=fit$rby, ggplot2::aes(ssb, rec, label = substr(year,3,4)),size=4,col="black",angle=45) +
+        ggplot2::theme(legend.position = c(0.20, 0.85)) +
+        ggplot2::labs(x = "Spawning stock biomass",
+                      y = "Recruitment",
+                      colour="Model")
+    } else {
+      ggplot2::ggplot(fit$rby) +
+        ggplot2::theme_bw() +
+        ggplot2::geom_point(ggplot2::aes(x=ssb,y=rec),size=1, alpha = 0.2) +
+        ggplot2::geom_line(data=modelLines,ggplot2::aes(ssb,rec,colour=Model),lwd=1.5) +
+        ggplot2::geom_path(data=fit$rby, ggplot2::aes(ssb, rec), col="black",linetype=2, lwd = 1) +
+        ggplot2::geom_text(data=fit$rby, ggplot2::aes(ssb, rec, label = substr(year,3,4)),size=4,col="black",angle=45) +
+        ggplot2::theme(legend.position = c(0.20, 0.85)) +
+        ggplot2::labs(x = "Spawning stock biomass",
+                      y = "Recruitment",
+                      colour="Model")
+    }
+
+  }
+}

--- a/R/eqsr_plot_iters.R
+++ b/R/eqsr_plot_iters.R
@@ -36,7 +36,7 @@ globalVariables(c("rec", "year", "Model", "p05", "p95", "p50"))
 #' }
 #'
 #' @export
-eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
+eqsr_plot_iters <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
                        ggPlot = FALSE, Scale = 1)
 {
   # get the draws from the SR parameter simulations

--- a/R/eqsr_plot_iters.R
+++ b/R/eqsr_plot_iters.R
@@ -43,7 +43,7 @@ eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
   modset <- fit$sr.sto
 
   # get the full data set
-  data <- fit$rby[,c("year", "rec", "ssb")]
+  data <- fit$rby[,c("year", "rec", "ssb", "iter")]
 
   # set up ranges
   minSSB <- min(data$ssb, max(data$ssb) * 0.0125)
@@ -62,7 +62,7 @@ eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
     sample_rec <- function(i) {
       # what SR model are we simulting from:
       FUN <-  match.fun(modset$model[i])
-      # simulate from _predictive_ distribrution of recruitment
+      # simulate from _predictive_ distribution of recruitment
       exp( FUN(modset[i,], ssb_eval) + stats::rnorm(length(ssb_eval), sd = modset $ cv[i]) )
     }
 
@@ -126,8 +126,8 @@ eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
     }
 
     # plot the observation points
-    lines(data$ssb, data$rec, col = "red")
-    points(data$ssb, data$rec, pch = 19, col = "red", cex = 1.25)
+    lines(data$ssb[data$iter==1], data$rec[data$iter==1], col = "red")
+    points(data$ssb[data$iter==1], data$rec[data$iter==1], pch = 19, col = "red", cex = 1.25)
     # plot the model weights on the graph
     for (i in 1:nrow(fit$sr.det)) {
       text(0.2 * maxSSB,
@@ -158,8 +158,9 @@ eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
     modelLines$ssb <- modelLines$ssb/Scale
     modelLines$rec <- modelLines$rec/Scale
 
-    fit$rby$ssb <- fit$rby$ssb/Scale
-    fit$rby$rec <- fit$rby$rec/Scale
+    fit.rby <- fit$rby[fit$rby$iter==1,]
+    fit.rby$ssb <- fit.rby$ssb/Scale
+    fit.rby$rec <- fit.rby$rec/Scale
 
     if (!is.null(modset)) {
       ggplot2::ggplot(out[i,]) +
@@ -170,14 +171,14 @@ eqsr_plot <- function (fit, n = 20000, x.mult = 1.1, y.mult = 1.4,
         ggplot2::geom_line(data=Percentiles,ggplot2::aes(ssb,p50),col="yellow", lwd = 1.5) +
         ggplot2::geom_line(data=modelLines,ggplot2::aes(ssb,rec,colour=Model),lwd=1.5) +
         ggplot2::coord_cartesian(ylim=c(0, stats::quantile(out$rec[i],0.99))) +
-        ggplot2::geom_path(data=fit$rby, ggplot2::aes(ssb, rec), col="black",linetype=2, lwd = 1) +
-        ggplot2::geom_text(data=fit$rby, ggplot2::aes(ssb, rec, label = substr(year,3,4)),size=4,col="black",angle=45) +
+        ggplot2::geom_path(data=fit.rby, ggplot2::aes(ssb, rec), col="black",linetype=2, lwd = 1) +
+        ggplot2::geom_text(data=fit.rby, ggplot2::aes(ssb, rec, label = substr(year,3,4)),size=4,col="black",angle=45) +
         ggplot2::theme(legend.position = c(0.20, 0.85)) +
         ggplot2::labs(x = "Spawning stock biomass",
                       y = "Recruitment",
                       colour="Model")
     } else {
-      ggplot2::ggplot(fit$rby) +
+      ggplot2::ggplot(fit.rby) +
         ggplot2::theme_bw() +
         ggplot2::geom_point(ggplot2::aes(x=ssb,y=rec),size=1, alpha = 0.2) +
         ggplot2::geom_line(data=modelLines,ggplot2::aes(ssb,rec,colour=Model),lwd=1.5) +

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -1,0 +1,73 @@
+#' Stock recruitment fitting
+#'
+#' Fits one or more stock recruitment relationships to data contained in `data`
+#' @param data must be a data frame containing columns `ssb` and `rec`
+#' @param nsamp Number of nonparametric bootstrap samples to take from the stock recruitment
+#'              data (default is 5000).  If 0 (zero) then only the fits to the
+#'              data are returned and no simulations are made.
+#' @param models A character vector containing stock recruitment models to fit. 
+#'               User can set any combination of
+#'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
+#' @export
+eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevholt"), ...)
+{
+  # useful objects
+  nllik <- function(param, ...) -1 * llik(param, ...)
+  ndat <- nrow(data)
+
+  #--------------------------------------------------------
+  # get best fit for each model
+  #--------------------------------------------------------
+  onefit <- function(mod) {
+    fit <-
+      stats::nlminb(
+        initial(mod, data),
+        nllik, data = data,
+        model = mod, logpar = TRUE,
+        control = list(iter.max = 500, eval.max = 500)
+      )
+    out <-
+      data.frame(
+        a = exp(fit$par[1]),
+        b = exp(fit$par[2]),
+        cv = exp(fit$par[3]),
+        llik = -1 * fit$objective,
+        model = mod,
+        stringsAsFactors = FALSE
+      )
+    out
+  }
+  sr.det <- do.call(rbind, lapply(models, onefit))
+  row.names(sr.det) <- NULL
+
+  if (nsamp > 0) {
+    #--------------------------------------------------------
+    # Fit models on bootstrap resamples
+    #--------------------------------------------------------
+    sr.sto <- lapply(1:nsamp, function(i)
+    {
+      sdat <- data[sample(1:ndat, replace = TRUE),]
+
+      fits <- lapply(models, function(mod) stats::nlminb(initial(mod, sdat), nllik, data = sdat, model = mod, logpar = TRUE))
+
+      best <- which.min(sapply(fits, "[[", "objective"))
+
+      with(fits[[best]], c(a = exp(par[1]), b = exp(par[2]), cv = exp(par[3]), model = best))
+    })
+
+    sr.sto <- as.data.frame(do.call(rbind, sr.sto))
+    sr.sto$model <- models[sr.sto$model]
+
+    # summarise and join to deterministic fit
+    tmp <- table(sr.sto$model)
+    sr.det$n <- unname(tmp[sr.det$model])
+    sr.det$prop <- sr.det$n / sum(sr.det$n)
+  } else {
+    sr.sto <- NULL
+    sr.det$n <- 0
+    sr.det$prop <- 0
+  }
+
+  #list(sr.sto = fit, sr.det = fits, pRec = pred)
+  list(sr.sto = sr.sto, sr.det = sr.det)
+}

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -9,7 +9,7 @@
 #'               User can set any combination of
 #'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
 #' @export
-eqsr_Buckland <- function(data, nsamp = dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
+eqsr_uncertainty_iters <- function(data, nsamp = dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
 {
   # useful objects
   nllik <- function(param, ...) -1 * llik(param, ...)

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -21,8 +21,8 @@ eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevh
   onefit <- function(mod) {
     fit <-
       stats::nlminb(
-        initial(mod, data),
-        nllik, data = data,
+        initial(mod, data[data$iter == 1, ]),
+        nllik, data = data[data$iter == 1, ],
         model = mod, logpar = TRUE,
         control = list(iter.max = 500, eval.max = 500)
       )

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -9,7 +9,7 @@
 #'               User can set any combination of
 #'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
 #' @export
-eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
+eqsr_Buckland <- function(data, nsamp = dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
 {
   # useful objects
   nllik <- function(param, ...) -1 * llik(param, ...)

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -9,12 +9,14 @@
 #'               User can set any combination of
 #'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
 #' @export
-eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevholt"), ...)
+eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
 {
   # useful objects
   nllik <- function(param, ...) -1 * llik(param, ...)
-  ndat <- nrow(data)
 
+  if (verbose)
+    message("Fitting SR model(s) to each replicate...")
+  
   #--------------------------------------------------------
   # get best fit for each model
   #--------------------------------------------------------
@@ -55,6 +57,9 @@ eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevh
       with(fits[[best]], c(a = exp(par[1]), b = exp(par[2]), cv = exp(par[3]), model = best, iter = i))
     })
 
+    if (verbose)
+    message("\n ...done!")
+    
     sr.sto <- as.data.frame(do.call(rbind, sr.sto))
     sr.sto$model <- models[sr.sto$model]
 

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -41,18 +41,18 @@ eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevh
   row.names(sr.det) <- NULL
 
   if (nsamp > 0) {
-    #--------------------------------------------------------
-    # Fit models on bootstrap resamples
-    #--------------------------------------------------------
-    sr.sto <- lapply(1:nsamp, function(i)
+    #------------------------------------------------------------------------
+    # Fit models to SR replicates extracted from iter dimension of stk object
+    #------------------------------------------------------------------------
+    sr.sto <- lapply(2:nsamp, function(i) # assume uncertainty in replicates 2+
     {
-      sdat <- data[sample(1:ndat, replace = TRUE),]
+      sdat <- data[data$iter == i, ]
 
       fits <- lapply(models, function(mod) stats::nlminb(initial(mod, sdat), nllik, data = sdat, model = mod, logpar = TRUE))
 
       best <- which.min(sapply(fits, "[[", "objective"))
 
-      with(fits[[best]], c(a = exp(par[1]), b = exp(par[2]), cv = exp(par[3]), model = best))
+      with(fits[[best]], c(a = exp(par[1]), b = exp(par[2]), cv = exp(par[3]), model = best, iter = i))
     })
 
     sr.sto <- as.data.frame(do.call(rbind, sr.sto))

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -9,8 +9,7 @@
 #'               User can set any combination of
 #'               "Ricker", "Segreg", "Bevholt", "Smooth_hockey".
 #' @export
-eqsr_uncertainty_iters <- function(data, nsamp = dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...)
-{
+eqsr_uncertainty_iters <- function(data, nsamp = dims(stk)$iter, models = c("Ricker","Segreg","Bevholt"), verbose = TRUE, ...){
   # useful objects
   nllik <- function(param, ...) -1 * llik(param, ...)
 
@@ -68,7 +67,7 @@ eqsr_uncertainty_iters <- function(data, nsamp = dims(stk)$iter, models = c("Ric
     sr.det$n <- unname(tmp[sr.det$model])
     sr.det[is.na(sr.det)] <- 0
     sr.det$prop <- sr.det$n / sum(sr.det$n)
-  } else {
+    } else {
     sr.sto <- NULL
     sr.det$n <- 0
     sr.det$prop <- 0

--- a/R/eqsr_uncertainty_iters.R
+++ b/R/eqsr_uncertainty_iters.R
@@ -61,6 +61,7 @@ eqsr_Buckland <- function(data, nsamp = 5000, models = c("Ricker","Segreg","Bevh
     # summarise and join to deterministic fit
     tmp <- table(sr.sto$model)
     sr.det$n <- unname(tmp[sr.det$model])
+    sr.det[is.na(sr.det)] <- 0
     sr.det$prop <- sr.det$n / sum(sr.det$n)
   } else {
     sr.sto <- NULL


### PR DESCRIPTION
## What?
Updated various EqSim functions (i.e. eqsr_fit, eqsr_Buckland, eqsr_fit_plot, eqsim_run, eqsim_plot) to utilise replicates stored in the iter dimension of an FLStock object.

## Why?
To explicitly account for assessment uncertainty. Replicates in the 'iter' dimension should represent assessment uncertainty e.g.  simulation replicates based on SAM’s variance-covariance matrix.

## How?
Replacing the resampling procedures (e.g. eqsr_Buckland) with procedures that utilise the replicates stored in the iter dimension of an FLStock object.